### PR TITLE
- Added MAX_TIMER_COUNT (100) safeguard to prevent PrometheusTimer ex…

### DIFF
--- a/monitoring-metric/src/main/java/com/monikit/metric/ExecutionDetailDurationMetricsBinder.java
+++ b/monitoring-metric/src/main/java/com/monikit/metric/ExecutionDetailDurationMetricsBinder.java
@@ -16,6 +16,7 @@ import java.util.concurrent.TimeUnit;
 
 public class ExecutionDetailDurationMetricsBinder implements MeterBinder {
 
+    private static final int MAX_TIMER_COUNT = 100;
     private final ConcurrentMap<String, Timer> timerCache = new ConcurrentHashMap<>();
     private MeterRegistry meterRegistry;
 
@@ -29,6 +30,10 @@ public class ExecutionDetailDurationMetricsBinder implements MeterBinder {
      */
     public void record(String className, String methodName, long durationMs, String tag) {
         String key = className + "." + methodName + "." + tag;
+
+        if (timerCache.size() >= MAX_TIMER_COUNT && !timerCache.containsKey(key)) {
+            return;
+        }
 
         Timer timer = timerCache.computeIfAbsent(key, k -> Timer.builder("execution_duration")
             .description("Method execution time in ms")

--- a/monitoring-starter/src/main/java/com/monikit/starter/DynamicMatcher.java
+++ b/monitoring-starter/src/main/java/com/monikit/starter/DynamicMatcher.java
@@ -43,6 +43,7 @@ public class DynamicMatcher {
         for (DynamicLogRule rule : rules) {
             if (!className.matches(rule.getClassNamePattern())) continue;
             if (!methodName.matches(rule.getMethodNamePattern())) continue;
+            if (executionTime < rule.getThresholdMillis()) continue;
 
             if (rule.getWhen() == null || rule.getWhen().isBlank()) return Optional.of(rule);
 


### PR DESCRIPTION
…plosion in:

  - HttpResponseDurationMetricsBinder
  - ExecutionDetailDurationMetricsBinder
  - SqlQueryDurationMetricsBinder
- DynamicMatcher now filters rules by thresholdMillis before evaluating SpEL  condition
- Reduced memory pressure in high-frequency execution paths by skipping excessive timer registration
- Updated normalizePath logic in HttpResponse binder to reduce tag cardinality